### PR TITLE
Improve Wi-Fi handling and CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E221,E302,E305,E306,E722,E702,F401,W391

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install deps
+        run: pip install flake8 pytest pytest-cov
+      - name: Lint
+        run: flake8
+      - name: Tests
+        run: pytest --cov=.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ python -m esptool --port COM3 write_flash -z 0x1000 micropython.bin
 
 > **Tip – WebREPL instead of USB**  
 > Replace every `connect COM3` with `connect ws:192.168.x.x` (or just omit `connect …` if `mpremote` has the board cached).
+
+
+## Boot behaviour
+
+The `boot.py` script now retries Wi-Fi connectivity until internet access is confirmed via NTP. If both Wi-Fi and internet fail after all retries the board deep sleeps for one minute before trying again.
+
+GitHub Actions run unit tests with coverage and report basic code quality via flake8.


### PR DESCRIPTION
## Summary
- improve Wi-Fi connect logic to check internet and deep sleep on failure
- add tests covering Wi-Fi connection logic
- document new boot behaviour
- add flake8 config and CI workflow

## Testing
- `flake8`
- `pytest -q`
- `pytest --cov=. -q`

------
https://chatgpt.com/codex/tasks/task_e_687a57ab3ea0832ea66bc5045a71bf63